### PR TITLE
Add concourse_windows.team property to spec

### DIFF
--- a/jobs/concourse_windows/spec
+++ b/jobs/concourse_windows/spec
@@ -23,6 +23,9 @@ properties:
   concourse_windows.tsa_worker_private_key:
     description: "Specifies the key to use when authenticating to the TSA."
     default: []
+  concourse_windows.team:
+    description: "Specifies the team this worker will be assigned to."
+    default: ""
   concourse_windows.bind_ip:
     description: "IP address on which to listen for the Garden server."
     default: 127.0.0.1

--- a/jobs/concourse_windows/templates/concourse_windows.ps1.erb
+++ b/jobs/concourse_windows/templates/concourse_windows.ps1.erb
@@ -4,4 +4,5 @@ C:\var\vcap\packages\concourse_windows\concourse_windows_amd64.exe worker `
     /tsa-public-key C:\var\vcap\jobs\concourse_windows\bin\tsa-public-key.pub `
     /tsa-worker-private-key C:\var\vcap\jobs\concourse_windows\bin\tsa-worker-private-key `
     /bind-ip <%= p("concourse_windows.bind_ip") %> `
-    /baggageclaim-bind-ip <%= p("concourse_windows.baggageclaim_bind_ip") %>
+    /baggageclaim-bind-ip <%= p("concourse_windows.baggageclaim_bind_ip") %> `
+    <%= "/team #{p("concourse_windows.team")}" if !p("concourse_windows.team").empty? %>


### PR DESCRIPTION
Adds an optional team property to the concourse_windows job spec.