### PR TITLE
Remove c:\var\vcap\bosh\bin from path

### DIFF
--- a/jobs/concourse_windows/templates/concourse_windows.ps1.erb
+++ b/jobs/concourse_windows/templates/concourse_windows.ps1.erb
@@ -1,3 +1,5 @@
+# Get rid of bosh's tar binary from the path which causes errors while extracting diego-release
+$env:Path = ($env:Path.Split(';') | Where-Object { $_ -ne 'c:\var\vcap\bosh\bin' }) -join ';'
 C:\var\vcap\packages\concourse_windows\concourse_windows_amd64.exe worker `
     /work-dir <%= p("concourse_windows.work_dir") %> `
     /tsa-host <%= p("concourse_windows.tsa_host") %> `


### PR DESCRIPTION
houdini attempts to use tar if it was found on the path. the tar binary that is
shipped with the bosh agent errors out while extracting diego-release. this
patch removes the tar from the path in order to force houdini to fallback to
using golang's stdlib

Signed-off-by: Chris Piraino <cpiraino@pivotal.io>